### PR TITLE
Modern char menu updates

### DIFF
--- a/code/__BLUEMOONCODE/_DEFINES/mobs.dm
+++ b/code/__BLUEMOONCODE/_DEFINES/mobs.dm
@@ -23,5 +23,8 @@
 // Scaled appearance modes
 #define SCALED_SHARP     0
 #define SCALED_FUZZY     1
+#define SCALED_PARTS     2 // WIP / тестовый режим, не доработан
+
+#define SCALED_MODES_COUNT 3
 
 #define SCALED_APPEARANCE_TRAIT "scaled_appearance"

--- a/code/__BLUEMOONCODE/_DEFINES/mobs.dm
+++ b/code/__BLUEMOONCODE/_DEFINES/mobs.dm
@@ -19,3 +19,9 @@
 //#define COST_WEIGHT_NORMAL 0 //PLACEHOLDER на случай если кто-то чего-то придумает с этим
 #define COST_WEIGHT_HEAVY 1
 #define COST_WEIGHT_HEAVY_SUPER 2
+
+// Scaled appearance modes
+#define SCALED_SHARP     0
+#define SCALED_FUZZY     1
+
+#define SCALED_APPEARANCE_TRAIT "scaled_appearance"

--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -211,3 +211,9 @@
 #define PREVIEW_PREF_LOADOUT "Loadout"
 #define PREVIEW_PREF_NAKED "Naked"
 #define PREVIEW_PREF_NAKED_AROUSED "Naked - Aroused"
+
+/// Подсказки для инкрементального обновления превью (preview_change_hint).
+/// Вместо полного regenerate_icons() вызывается только нужный update_*().
+#define PREVIEW_HINT_HAIR "hair"
+#define PREVIEW_HINT_BODY "body"
+#define PREVIEW_HINT_MUTANT_BODYPARTS "mutant_bodyparts"

--- a/code/modules/client/hair_style_picker.dm
+++ b/code/modules/client/hair_style_picker.dm
@@ -14,6 +14,14 @@
 	var/preview_icon64 = null
 	var/preview_generating = FALSE
 	var/preview_pending = FALSE
+	var/last_preview_time = 0
+	var/preview_timer_id = null
+	/// Cached mannequin — held for the lifetime of the picker to avoid copy_to on every click
+	var/mob/living/carbon/human/dummy/cached_mannequin
+	var/mannequin_initialized = FALSE
+	var/dummy_slot_key
+	/// Кэш плоской иконки манекена БЕЗ hair layer — для быстрой композиции при переборе причёсок.
+	var/icon/cached_base_icon = null
 
 	// Статический кэш base64 иконок по типу.
 	var/static/list/hair_icon_cache = null
@@ -27,6 +35,7 @@
 		holder = user.client
 	prefs = holder.prefs
 	pick_type = type
+	dummy_slot_key = "hair_picker_[REF(src)]"
 	rebuild_filtered(search_text)
 	load_page_icons()
 	INVOKE_ASYNC(src, PROC_REF(_preload_remaining_icons)) // фоновый прогрев оставшихся страниц
@@ -37,6 +46,16 @@
 	if(!ui)
 		ui = new(user, src, "HairStylePicker", pick_type == "hair" ? "Выбор Причёски" : pick_type == "facial_hair" ? "Выбор Стиля Бороды" : "Выбор Цветового Перехода")
 		ui.open()
+
+/datum/tgui_hair_style_picker/Destroy()
+	if(preview_timer_id)
+		deltimer(preview_timer_id)
+		preview_timer_id = null
+	if(cached_mannequin)
+		unset_busy_human_dummy(dummy_slot_key)
+		cached_mannequin = null
+	cached_base_icon = null
+	return ..()
 
 /datum/tgui_hair_style_picker/ui_close(mob/user)
 	qdel(src)
@@ -62,8 +81,8 @@
 			data["current_style"] = prefs.facial_hair_style
 		if("gradient")
 			data["current_style"] = prefs.grad_style
-	data["filtered_names"] = filtered_names.Copy()
-	data["loaded_icons"] = current_icons.Copy()
+	data["filtered_names"] = filtered_names
+	data["loaded_icons"] = current_icons
 	data["preview_icon64"] = preview_icon64
 	return data
 
@@ -180,19 +199,86 @@
 	if(preview_generating)
 		preview_pending = TRUE
 		return
+	// Throttle: максимум ~3 превью в секунду (3 тика = 0.3с)
+	// С кэшированной базой каждый рендер быстрый, можно снизить throttle
+	var/time_since_last = world.time - last_preview_time
+	if(time_since_last < 3)
+		if(!preview_timer_id)
+			preview_timer_id = addtimer(CALLBACK(src, PROC_REF(_throttled_preview)), 3 - time_since_last, TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_STOPPABLE)
+		return
+	last_preview_time = world.time
+	INVOKE_ASYNC(src, PROC_REF(_do_refresh_preview))
+
+/datum/tgui_hair_style_picker/proc/_throttled_preview()
+	preview_timer_id = null
+	if(QDELETED(src))
+		return
+	last_preview_time = world.time
 	INVOKE_ASYNC(src, PROC_REF(_do_refresh_preview))
 
 /datum/tgui_hair_style_picker/proc/_do_refresh_preview()
 	preview_generating = TRUE
 	preview_pending = FALSE
-	var/species_id = prefs.pref_species ? prefs.pref_species.id : "null"
-	var/cache_key = "hairpick_[prefs.hair_style]_[prefs.hair_color]_[prefs.grad_style]_[prefs.facial_hair_style]_[prefs.facial_hair_color]_[prefs.skin_tone]_[species_id]"
-	var/dummy_slot = "hair_picker_preview_[REF(src)]"
-	var/icon/I = get_flat_human_icon(cache_key, null, prefs, dummy_slot, list(SOUTH), null, TRUE)
+	// Первый вызов — полная инициализация манекена (copy_to + regenerate_icons)
+	// Последующие — только обновляем изменившееся поле (hair/facial/grad) + update_hair()
+	if(!mannequin_initialized || QDELETED(cached_mannequin))
+		cached_mannequin = generate_or_wait_for_human_dummy(dummy_slot_key)
+		if(!cached_mannequin || QDELETED(src))
+			preview_generating = FALSE
+			return
+		prefs.copy_to(cached_mannequin, initial_spawn = TRUE)
+		cached_mannequin.regenerate_icons()
+		mannequin_initialized = TRUE
+		// Кэшируем базовую иконку БЕЗ hair layer — для быстрой композиции в дальнейшем
+		cached_mannequin.remove_overlay(HAIR_LAYER)
+		cached_base_icon = getFlatIcon(cached_mannequin, defdir = SOUTH, no_anim = TRUE)
+		cached_mannequin.update_hair() // вернуть hair overlay
+	else
+		// Инкрементальное обновление — только изменившееся поле + пересборка hair-оверлеев
+		switch(pick_type)
+			if("hair")
+				cached_mannequin.hair_style = prefs.hair_style
+			if("facial_hair")
+				cached_mannequin.facial_hair_style = prefs.facial_hair_style
+			if("gradient")
+				cached_mannequin.grad_style = prefs.grad_style
+		cached_mannequin.update_hair()
 	if(QDELETED(src))
 		return
+	// Если есть кэш базовой иконки — композиция вместо дорогого getFlatIcon()
+	var/icon/I
+	if(cached_base_icon)
+		I = icon(cached_base_icon) // копия кэшированной базы
+		// Берём hair-оверлеи с манекена и блендим поверх базы
+		var/overlays_data = cached_mannequin.overlays_standing[HAIR_LAYER]
+		if(overlays_data)
+			var/list/overlay_list
+			if(islist(overlays_data))
+				overlay_list = overlays_data
+			else
+				overlay_list = list(overlays_data)
+			for(var/mutable_appearance/MA in overlay_list)
+				if(!MA.icon || !MA.icon_state)
+					continue
+				var/icon/hair_part = icon(MA.icon, MA.icon_state, SOUTH, 1)
+				if(MA.color)
+					hair_part.Blend(MA.color, ICON_MULTIPLY)
+				if(MA.alpha < 255)
+					hair_part.Blend(rgb(255, 255, 255, MA.alpha), ICON_MULTIPLY)
+				I.Blend(hair_part, ICON_OVERLAY, MA.pixel_x, MA.pixel_y)
+	else
+		// Fallback — полный getFlatIcon() если кэш не создан
+		I = getFlatIcon(cached_mannequin, defdir = SOUTH, no_anim = TRUE)
+	if(QDELETED(src))
+		return
+	// Request cancellation: если пришёл новый запрос, пропускаем дорогой icon2html() —
+	// текущий результат всё равно устареет, а icon2html() не бесплатен
+	if(preview_pending)
+		preview_generating = FALSE
+		refresh_preview_icon()
+		return
 	if(I)
-		preview_icon64 = icon2html(I, holder, sourceonly = TRUE) // asset URL, не base64
+		preview_icon64 = icon2html(I, holder, sourceonly = TRUE)
 	else
 		preview_icon64 = null
 	preview_generating = FALSE

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -297,7 +297,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 "meat_type" = "Mammalian",
 "body_model" = MALE,
 "body_size" = RESIZE_DEFAULT_SIZE,
-"fuzzy" = FALSE,
+"fuzzy" = SCALED_SHARP,
 "color_scheme" = OLD_CHARACTER_COLORING,
 "neckfire" = FALSE,
 "neckfire_color" = "ffffff",
@@ -406,6 +406,14 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	// Guard flag — TRUE пока ассинхронная генерация работает.
 	var/preview_generating = FALSE
 	var/tmp/pending_preview_update = FALSE
+	/// Кэш иконок превью по направлениям (dir -> html string). Сбрасывается при изменении внешности.
+	var/tmp/list/preview_dir_cache
+	/// Зум превью в процентах (100-200, шаг 10) — session-only, не сохраняется.
+	var/tmp/preview_zoom = 100
+	/// Показывать эталонный манекен (100% размер) за спрайтом для сравнения.
+	var/tmp/preview_show_reference = FALSE
+	/// Кэш иконок эталонного манекена (dir -> html string).
+	var/tmp/list/preview_reference_cache
 
 	var/no_tetris_storage = FALSE
 
@@ -516,7 +524,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	// Splurt extras
 	var/unholypref = "No" //Goin 2 hell fo dis one
 	var/list/gfluid_blacklist = list() //Stuff you don't want people to cum into you
-	var/fuzzy = FALSE //Fuzzy scaling
+	var/fuzzy = SCALED_SHARP //Scaled appearance mode: 0=Sharp, 1=Fuzzy
 
 	// BlueMoon extras
 	var/body_weight = NAME_WEIGHT_NORMAL

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -415,6 +415,15 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	/// Кэш иконок эталонного манекена (dir -> html string).
 	var/tmp/list/preview_reference_cache
 
+	/// Персистентный манекен для превью — не пересоздаётся каждый раз.
+	var/tmp/mob/living/carbon/human/dummy/preview_mannequin
+	/// TRUE если манекен уже инициализирован (copy_to вызван). Сбрасывается при смене species/gender/etc.
+	var/tmp/preview_mannequin_initialized = FALSE
+	/// Подсказка для инкрементального обновления — какие слои обновлять вместо полного regenerate_icons().
+	/// Устанавливается обработчиками настроек перед вызовом update_preview_icon().
+	/// null = полная пересборка.
+	var/tmp/preview_change_hint
+
 	var/no_tetris_storage = FALSE
 
 	///loadout stuff

--- a/code/modules/client/preferences_copy_to.dm
+++ b/code/modules/client/preferences_copy_to.dm
@@ -266,7 +266,11 @@
 ///Searching for loadout item which `property` ([LOADOUT_ITEM], [LOADOUT_COLOR], etc) equals to `value`; returns this items, or FALSE if no gear matched conditions
 /datum/preferences/proc/find_gear_with_property(save_slot, property, value)
 	var/list/gear_list = loadout_data["SAVE_[save_slot]"]
+	if(!islist(gear_list))
+		return FALSE
 	for(var/loadout_gear in gear_list)
+		if(!islist(loadout_gear))
+			continue
 		if(loadout_gear[property] == value)
 			return loadout_gear
 	return FALSE
@@ -276,6 +280,8 @@
 	if(!islist(gear_list))
 		return FALSE
 	for(var/loadout_gear in gear_list)
+		if(!islist(loadout_gear))
+			continue
 		if(loadout_gear[LOADOUT_ITEM] == gear_type)
 			return loadout_gear
 	return FALSE

--- a/code/modules/client/preferences_handlers.dm
+++ b/code/modules/client/preferences_handlers.dm
@@ -1770,7 +1770,7 @@
 						features["body_size"] = clamp(new_body_size * 0.01, CONFIG_GET(number/body_size_min), CONFIG_GET(number/body_size_max))
 
 				if("toggle_fuzzy")
-					fuzzy = !fuzzy
+					fuzzy = (fuzzy + 1) % 2
 
 				//BLUEMOON ADD выбор веса персонажа, замена квирков на вес
 				if("body_weight")
@@ -2652,7 +2652,26 @@
 					var/new_dir = text2num(href_list["dir"])
 					if(new_dir in GLOB.cardinals)
 						preview_direction = new_dir
+						// Если есть закэшированная иконка для этого направления — используем мгновенно
+						if(LAZYACCESS(preview_dir_cache, "[new_dir]"))
+							preview_icon64 = preview_dir_cache["[new_dir]"]
+							skip_preview = TRUE
+						else
+							update_preview_icon()
+							skip_preview = TRUE
+
+				if("preview_zoom")
+					var/new_zoom = text2num(href_list["level"])
+					if(isnum(new_zoom))
+						preview_zoom = clamp(round(new_zoom, 10), 100, 200)
+					skip_preview = TRUE
+
+				if("preview_reference")
+					preview_show_reference = !preview_show_reference
+					if(preview_show_reference && !LAZYLEN(preview_reference_cache))
+						// Кэша нет — запускаем генерацию, ShowChoices вызовется по завершению
 						update_preview_icon()
+					skip_preview = TRUE
 
 				if("character_tab")
 					skip_preview = TRUE
@@ -2849,10 +2868,11 @@
 			if(!thing_to_remove)
 				return
 			var/list/sanitize_current_slot = loadout_data["SAVE_[loadout_slot]"]
-			for(var/list/entry in sanitize_current_slot)
-				if(entry["loadout_item"] == thing_to_remove)
-					sanitize_current_slot.Remove(list(entry))
-					break
+			if(islist(sanitize_current_slot))
+				for(var/list/entry in sanitize_current_slot)
+					if(entry["loadout_item"] == thing_to_remove)
+						sanitize_current_slot.Remove(list(entry))
+						break
 
 		if(href_list["loadout_color"] || href_list["loadout_color_polychromic"] || href_list["loadout_color_HSV"] || href_list["loadout_rename"] || href_list["loadout_redescribe"] || href_list["loadout_addheirloom"] || href_list["loadout_removeheirloom"] || href_list["loadout_tagname"] || href_list["loadout_examtooltip"])
 

--- a/code/modules/client/preferences_handlers.dm
+++ b/code/modules/client/preferences_handlers.dm
@@ -1,6 +1,7 @@
 /datum/preferences/Topic(href, href_list, hsrc)			//yeah, gotta do this I guess..
 	. = ..()
 	if(href_list["close"])
+		release_preview_mannequin()
 		var/client/C = usr.client
 		if(C)
 			C.clear_character_previews()
@@ -373,12 +374,16 @@
 					age = rand(AGE_MIN, AGE_MAX)
 				if("hair")
 					hair_color = random_short_color()
+					preview_change_hint = PREVIEW_HINT_HAIR
 				if("hair_style")
 					hair_style = random_hair_style(gender)
+					preview_change_hint = PREVIEW_HINT_HAIR
 				if("facial")
 					facial_hair_color = random_short_color()
+					preview_change_hint = PREVIEW_HINT_HAIR
 				if("facial_hair_style")
 					facial_hair_style = random_facial_hair_style(gender)
+					preview_change_hint = PREVIEW_HINT_HAIR
 				/*
 				if("underwear")
 					underwear = random_underwear(gender)
@@ -394,15 +399,18 @@
 					var/random_eye_color = random_eye_color()
 					left_eye_color = random_eye_color
 					right_eye_color = random_eye_color
+					preview_change_hint = PREVIEW_HINT_BODY
 				if("s_tone")
 					skin_tone = random_skin_tone()
 					use_custom_skin_tone = null
+					preview_change_hint = PREVIEW_HINT_BODY
 				if("bag")
 					backbag = pick(GLOB.backbaglist)
 				if("suit")
 					jumpsuit_style = pick(GLOB.jumpsuitlist)
 				if("all")
 					random_character()
+					invalidate_preview_mannequin()
 
 		if("input")
 
@@ -555,12 +563,14 @@
 					var/new_hair = input(user, "Choose your character's hair colour:", "Character Preference","#"+hair_color) as color|null
 					if(new_hair)
 						hair_color = sanitize_hexcolor(new_hair, 6)
+						preview_change_hint = PREVIEW_HINT_HAIR
 
 				if("hair_style")
 					var/new_hair_style
 					new_hair_style = tgui_input_list(user, "Choose your character's hair style:", "Character Preference", GLOB.hair_styles_list)
 					if(new_hair_style)
 						hair_style = new_hair_style
+						preview_change_hint = PREVIEW_HINT_HAIR
 
 				if("open_hair_picker")
 					var/datum/tgui_hair_style_picker/picker = new(user, "hair")
@@ -569,20 +579,24 @@
 
 				if("next_hair_style")
 					hair_style = next_list_item(hair_style, GLOB.hair_styles_list)
+					preview_change_hint = PREVIEW_HINT_HAIR
 
 				if("previous_hair_style")
 					hair_style = previous_list_item(hair_style, GLOB.hair_styles_list)
+					preview_change_hint = PREVIEW_HINT_HAIR
 
 				if("facial")
 					var/new_facial = input(user, "Choose your character's facial-hair colour:", "Character Preference","#"+facial_hair_color) as color|null
 					if(new_facial)
 						facial_hair_color = sanitize_hexcolor(new_facial, 6)
+						preview_change_hint = PREVIEW_HINT_HAIR
 
 				if("facial_hair_style")
 					var/new_facial_hair_style
 					new_facial_hair_style = tgui_input_list(user, "Choose your character's facial-hair style:", "Character Preference", GLOB.facial_hair_styles_list)
 					if(new_facial_hair_style)
 						facial_hair_style = new_facial_hair_style
+						preview_change_hint = PREVIEW_HINT_HAIR
 
 				if("open_facial_hair_picker")
 					var/datum/tgui_hair_style_picker/picker = new(user, "facial_hair")
@@ -591,20 +605,24 @@
 
 				if("next_facehair_style")
 					facial_hair_style = next_list_item(facial_hair_style, GLOB.facial_hair_styles_list)
+					preview_change_hint = PREVIEW_HINT_HAIR
 
 				if("previous_facehair_style")
 					facial_hair_style = previous_list_item(facial_hair_style, GLOB.facial_hair_styles_list)
+					preview_change_hint = PREVIEW_HINT_HAIR
 
 				if("grad_color")
 					var/new_grad_color = input(user, "Choose your character's gradient colour:", "Character Preference","#"+grad_color) as color|null
 					if(new_grad_color)
 						grad_color = sanitize_hexcolor(new_grad_color, 6)
+						preview_change_hint = PREVIEW_HINT_HAIR
 
 				if("grad_style")
 					var/new_grad_style
 					new_grad_style = tgui_input_list(user, "Choose your character's hair gradient style:", "Character Preference", GLOB.hair_gradients_list)
 					if(new_grad_style)
 						grad_style = new_grad_style
+						preview_change_hint = PREVIEW_HINT_HAIR
 
 				if("open_gradient_picker")
 					var/datum/tgui_hair_style_picker/picker = new(user, "gradient")
@@ -613,18 +631,22 @@
 
 				if("next_grad_style")
 					grad_style = next_list_item(grad_style, GLOB.hair_gradients_list)
+					preview_change_hint = PREVIEW_HINT_HAIR
 
 				if("previous_grad_style")
 					grad_style = previous_list_item(grad_style, GLOB.hair_gradients_list)
+					preview_change_hint = PREVIEW_HINT_HAIR
 
 				// BLUEMOON ADD START - <_AND_>_FOR_CHARACTER_REDACTOR
 
 				// HORNS
 				if("next_horns_style")
 					features["horns"] = next_list_item(features["horns"], GLOB.horns_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				if("previous_horns_style")
 					features["horns"] = previous_list_item(features["horns"], GLOB.horns_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				// MEAT TYPE
 				if("next_meat_type_style")
@@ -636,163 +658,209 @@
 				// IPC ANTENNA
 				if("next_ipc_antenna_style")
 					features["ipc_antenna"] = next_list_item(features["ipc_antenna"], GLOB.ipc_antennas_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				if("previous_ipc_antenna_style")
 					features["ipc_antenna"] = previous_list_item(features["ipc_antenna"], GLOB.ipc_antennas_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				// IPC SCREENS
 				if("next_ipc_screen_style")
 					features["ipc_screen"] = next_list_item(features["ipc_screen"], GLOB.ipc_screens_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				if("previous_ipc_screen_style")
 					features["ipc_screen"] = previous_list_item(features["ipc_screen"], GLOB.ipc_screens_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				// XENO DORSALS
 				if("next_xenodorsal_style")
 					features["xenodorsal"] = next_list_item(features["xenodorsal"], GLOB.xeno_dorsal_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				if("previous_xenodorsal_style")
 					features["xenodorsal"] = previous_list_item(features["xenodorsal"], GLOB.xeno_dorsal_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				// XENO TAILS
 				if("next_xenotail_style")
 					features["xenotail"] = next_list_item(features["xenotail"], GLOB.xeno_tail_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				if("previous_xenotail_style")
 					features["xenotail"] = previous_list_item(features["xenotail"], GLOB.xeno_tail_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				// XENO HEADS
 				if("next_xenohead_style")
 					features["xenohead"] = next_list_item(features["xenohead"], GLOB.xeno_head_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				if("previous_xenohead_style")
 					features["xenohead"] = previous_list_item(features["xenohead"], GLOB.xeno_head_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				// ARACHNIDS MANDIBLES
 				if("next_arachnid_mandibles_style")
 					features["arachnid_mandibles"] = next_list_item(features["arachnid_mandibles"], GLOB.arachnid_mandibles_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				if("previous_arachnid_mandibles_style")
 					features["arachnid_mandibles"] = previous_list_item(features["arachnid_mandibles"], GLOB.arachnid_mandibles_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				// ARACHINDS SPHINNERET
 				if("next_arachnid_spinneret_style")
 					features["arachnid_spinneret"] = next_list_item(features["arachnid_spinneret"], GLOB.arachnid_spinneret_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				if("previous_arachnid_spinneret_style")
 					features["arachnid_spinneret"] = previous_list_item(features["arachnid_spinneret"], GLOB.arachnid_spinneret_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				// ARACHNIDS LEGS
 				if("next_arachnid_legs_style")
 					features["arachnid_legs"] = next_list_item(features["arachnid_legs"], GLOB.arachnid_legs_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				if("previous_arachnid_legs_style")
 					features["arachnid_legs"] = previous_list_item(features["arachnid_legs"], GLOB.arachnid_legs_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				// WINGS
 				if("next_wings_style")
 					features["wings"] = next_list_item(features["wings"], GLOB.wings_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				if("previous_wings_style")
 					features["wings"] = previous_list_item(features["wings"], GLOB.wings_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				// TAUR BODY
 				if("next_taur_style")
 					features["taur"] = next_list_item(features["taur"], GLOB.taur_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				if("previous_taur_style")
 					features["taur"] = previous_list_item(features["taur"], GLOB.taur_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				// INSECT FLUFF (NECK AND SPINE)
 				if("next_insect_fluff_style")
 					features["insect_fluff"] = next_list_item(features["insect_fluff"], GLOB.insect_fluffs_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				if("previous_insect_fluff_style")
 					features["insect_fluff"] = previous_list_item(features["insect_fluff"], GLOB.insect_fluffs_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				// INSECT WINGS
 				if("next_insect_wings_style")
 					features["insect_wings"] = next_list_item(features["insect_wings"], GLOB.insect_wings_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				if("previous_insect_wings_style")
 					features["insect_wings"] = previous_list_item(features["insect_wings"], GLOB.insect_wings_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				// DECO WINGS
 				if("next_deco_wings_style")
 					features["deco_wings"] = next_list_item(features["deco_wings"], GLOB.deco_wings_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				if("previous_deco_wings_style")
 					features["deco_wings"] = previous_list_item(features["deco_wings"], GLOB.deco_wings_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				// LEGS
 				if("next_legs_style")
 					features["legs"] = next_list_item(features["legs"], GLOB.legs_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				if("previous_legs_style")
 					features["legs"] = previous_list_item(features["legs"], GLOB.legs_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				// MAMMAL SNOUTS
 				if("next_mam_snouts_style")
 					features["mam_snouts"] = next_list_item(features["mam_snouts"], GLOB.mam_snouts_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				if("previous_mam_snouts_style")
 					features["mam_snouts"] = previous_list_item(features["mam_snouts"], GLOB.mam_snouts_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				// EARS
 				if("next_ears_style")
 					features["ears"] = next_list_item(features["ears"], GLOB.ears_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				if("previous_ears_style")
 					features["ears"] = previous_list_item(features["ears"], GLOB.ears_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				// MAMMAL EARS
 				if("next_mam_ears_style")
 					features["mam_ears"] = next_list_item(features["mam_ears"], GLOB.mam_ears_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				if("previous_mam_ears_style")
 					features["mam_ears"] = previous_list_item(features["mam_ears"], GLOB.mam_ears_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				// LIZARDS SPINES
 				if("next_spines_style")
 					features["spines"] = next_list_item(features["spines"], GLOB.spines_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				if("previous_spines_style")
 					features["spines"] = previous_list_item(features["spines"], GLOB.spines_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				// LIZARDS FRILLS
 				if("next_frills_style")
 					features["frills"] = next_list_item(features["frills"], GLOB.frills_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				if("previous_frills_style")
 					features["frills"] = previous_list_item(features["frills"], GLOB.frills_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				// LIZARDS SNOUTS
 				if("next_snout_style")
 					features["snout"] = next_list_item(features["snout"], GLOB.snouts_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				if("previous_snout_style")
 					features["snout"] = previous_list_item(features["snout"], GLOB.snouts_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				// HUMAN TAILS
 				if("next_tail_human_style")
 					features["tail_human"] = next_list_item(features["tail_human"], GLOB.tails_list_human)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				if("previous_tail_human_style")
 					features["tail_human"] = previous_list_item(features["tail_human"], GLOB.tails_list_human)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				// LIZARDS TAILS
 				if("next_tail_lizard_style")
 					features["tail_lizard"] = next_list_item(features["tail_lizard"], GLOB.tails_list_lizard)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				if("previous_tail_lizard_style")
 					features["tail_lizard"] = previous_list_item(features["tail_lizard"], GLOB.tails_list_lizard)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				// MAMMAL TAILS
 				if("next_mam_tail_style")
 					features["mam_tail"] = next_list_item(features["mam_tail"], GLOB.mam_tails_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 
 				if("previous_mam_tail_style")
 					features["mam_tail"] = previous_list_item(features["mam_tail"], GLOB.mam_tails_list)
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 				// BLUEMOON ADD END
 
 				if("cycle_bg")
@@ -858,25 +926,30 @@
 					if(new_eyes)
 						left_eye_color = sanitize_hexcolor(new_eyes, 6)
 						right_eye_color = sanitize_hexcolor(new_eyes, 6)
+						preview_change_hint = PREVIEW_HINT_BODY
 
 				if("eye_left")
 					var/new_eyes = input(user, "Choose your character's left eye colour:", "Character Preference","#"+left_eye_color) as color|null
 					if(new_eyes)
 						left_eye_color = sanitize_hexcolor(new_eyes, 6)
+						preview_change_hint = PREVIEW_HINT_BODY
 
 				if("eye_right")
 					var/new_eyes = input(user, "Choose your character's right eye colour:", "Character Preference","#"+right_eye_color) as color|null
 					if(new_eyes)
 						right_eye_color = sanitize_hexcolor(new_eyes, 6)
+						preview_change_hint = PREVIEW_HINT_BODY
 
 				if("eye_type")
 					var/new_eye_type = tgui_input_list(user, "Choose your character's eye type.", "Character Preference", GLOB.eye_types)
 					if(new_eye_type)
 						eye_type = new_eye_type
+						preview_change_hint = PREVIEW_HINT_BODY
 
 				if("toggle_split_eyes")
 					split_eye_colors = !split_eye_colors
 					right_eye_color = left_eye_color
+					preview_change_hint = PREVIEW_HINT_BODY
 
 				if("species")
 					var/result = tgui_input_list(user, "Select a species", "Species Selection", GLOB.roundstart_race_names)
@@ -907,6 +980,7 @@
 
 						//switch to the type of eyes the species uses
 						eye_type = pref_species.eye_type
+						invalidate_preview_mannequin()
 
 				if("custom_species")
 					var/new_species = reject_bad_name(input(user, "Выберите особую расу персонажа, если он уникален. Это будет отображаться при осмотре и сканировании здоровья. Не злоупотребляйте этим:", "Character Preference", custom_species) as null|text, TRUE)
@@ -921,8 +995,10 @@
 						var/temp_hsv = RGBtoHSV(new_mutantcolor)
 						if(new_mutantcolor == "#000000" && features["mcolor"] != pref_species.default_color) //SPLURT EDIT
 							features["mcolor"] = pref_species.default_color
+							preview_change_hint = PREVIEW_HINT_BODY
 						else if((MUTCOLORS_PARTSONLY in pref_species.species_traits) || ReadHSV(temp_hsv)[3] >= ReadHSV(MINIMUM_MUTANT_COLOR)[3] || !CONFIG_GET(flag/character_color_limits)) // mutantcolors must be bright, but only if they affect the skin //SPLURT EDIT
 							features["mcolor"] = sanitize_hexcolor(new_mutantcolor, 6)
+							preview_change_hint = PREVIEW_HINT_BODY
 						else
 							to_chat(user, "<span class='danger'>Invalid color. Your color is not bright enough.</span>")
 
@@ -932,8 +1008,10 @@
 						var/temp_hsv = RGBtoHSV(new_mutantcolor)
 						if(new_mutantcolor == "#000000" && features["mcolor2"] != pref_species.default_color) //SPLURT EDIT
 							features["mcolor2"] = pref_species.default_color
+							preview_change_hint = PREVIEW_HINT_BODY
 						else if((MUTCOLORS_PARTSONLY in pref_species.species_traits) || ReadHSV(temp_hsv)[3] >= ReadHSV(MINIMUM_MUTANT_COLOR)[3] || !CONFIG_GET(flag/character_color_limits)) // mutantcolors must be bright, but only if they affect the skin //SPLURT EDIT
 							features["mcolor2"] = sanitize_hexcolor(new_mutantcolor, 6)
+							preview_change_hint = PREVIEW_HINT_BODY
 						else
 							to_chat(user, "<span class='danger'>Invalid color. Your color is not bright enough.</span>")
 
@@ -943,8 +1021,10 @@
 						var/temp_hsv = RGBtoHSV(new_mutantcolor)
 						if(new_mutantcolor == "#000000" && features["mcolor3"] != pref_species.default_color) //SPLURT EDIT
 							features["mcolor3"] = pref_species.default_color
+							preview_change_hint = PREVIEW_HINT_BODY
 						else if((MUTCOLORS_PARTSONLY in pref_species.species_traits) || ReadHSV(temp_hsv)[3] >= ReadHSV(MINIMUM_MUTANT_COLOR)[3] || !CONFIG_GET(flag/character_color_limits)) // mutantcolors must be bright, but only if they affect the skin //SPLURT EDIT
 							features["mcolor3"] = sanitize_hexcolor(new_mutantcolor, 6)
+							preview_change_hint = PREVIEW_HINT_BODY
 						else
 							to_chat(user, "<span class='danger'>Invalid color. Your color is not bright enough.</span>")
 
@@ -956,6 +1036,7 @@
 
 				if("has_neckfire")
 					features["neckfire"] = !features["neckfire"]
+					preview_change_hint = PREVIEW_HINT_MUTANT_BODYPARTS
 				if("has_neckfire_color")
 					var/new_neckfire_color = input(user, "Choose your fire's color:", "Character Preference", "#"+features["neckfire_color"]) as color|null
 					if(new_neckfire_color)
@@ -1763,14 +1844,17 @@
 						else
 							features["body_model"] = chosengender
 					gender = chosengender
+					invalidate_preview_mannequin()
 
 				if("body_size")
 					var/new_body_size = input(user, "Choose your desired sprite size: ([CONFIG_GET(number/body_size_min)*100]-[CONFIG_GET(number/body_size_max)*100]%)\nWarning: This may make your character look distorted. Additionally, any size affects speed and max health", "Character Preference", features["body_size"]*100) as num|null
 					if(new_body_size)
 						features["body_size"] = clamp(new_body_size * 0.01, CONFIG_GET(number/body_size_min), CONFIG_GET(number/body_size_max))
+						invalidate_preview_mannequin()
 
 				if("toggle_fuzzy")
-					fuzzy = (fuzzy + 1) % 2
+					fuzzy = (fuzzy + 1) % SCALED_MODES_COUNT
+					invalidate_preview_mannequin()
 
 				//BLUEMOON ADD выбор веса персонажа, замена квирков на вес
 				if("body_weight")
@@ -2246,6 +2330,7 @@
 
 				if("body_model")
 					features["body_model"] = features["body_model"] == MALE ? FEMALE : MALE
+					invalidate_preview_mannequin()
 
 				if("hotkeys")
 					hotkeys = !hotkeys
@@ -2628,8 +2713,10 @@
 				if("load")
 					load_preferences()
 					load_character()
+					invalidate_preview_mannequin()
 
 				if("changeslot")
+					invalidate_preview_mannequin()
 					if(char_queue)
 						deltimer(char_queue) // Do not dare.
 					if(!load_character(text2num(href_list["num"])))
@@ -2655,6 +2742,8 @@
 						// Если есть закэшированная иконка для этого направления — используем мгновенно
 						if(LAZYACCESS(preview_dir_cache, "[new_dir]"))
 							preview_icon64 = preview_dir_cache["[new_dir]"]
+							// Targeted update — не пересоздаём 2500+ строк HTML ради смены направления
+							update_preview_html_only(user)
 							skip_preview = TRUE
 						else
 							update_preview_icon()
@@ -2984,7 +3073,14 @@
 				else
 					user_gear -= "loadout_examtooltip"
 
-	ShowChoices(user, skip_preview_update = skip_preview)
+	// Оптимизация: если изменение влияет ТОЛЬКО на внешность (есть preview_change_hint),
+	// вызываем ShowChoices с skip_preview=TRUE (HTML обновится, но без дорогой генерации превью),
+	// а превью обновляем отдельно через инкрементальный update_preview_icon().
+	if(preview_change_hint && !skip_preview)
+		update_preview_icon()
+		ShowChoices(user, skip_preview_update = TRUE)
+	else
+		ShowChoices(user, skip_preview_update = skip_preview)
 	return TRUE
 
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -1475,6 +1475,12 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 			else
 				loadout_data[save_key] = list()
 
+	// Ensure SAVE_X keys exist even when loadout data wasn't loaded from text (old savefile format)
+	for(var/ensure_idx = 1, ensure_idx <= MAXIMUM_LOADOUT_SAVES, ensure_idx++)
+		var/ensure_key = "SAVE_[ensure_idx]"
+		if(!islist(loadout_data[ensure_key]))
+			loadout_data[ensure_key] = list()
+
 	//let's remember their last used slot, i'm sure "oops i brought the wrong stuff" will be an issue now
 	S["loadout_slot"] >> loadout_slot
 	// BLUEMOON ADD - загрузка переключателя лодаута

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -1509,7 +1509,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	nameless = sanitize_integer(nameless, 0, 1, initial(nameless))
 	be_random_name = sanitize_integer(be_random_name, 0, 1, initial(be_random_name))
 	be_random_body = sanitize_integer(be_random_body, 0, 1, initial(be_random_body))
-	features["fuzzy"] = sanitize_integer(features["fuzzy"], 0, 1, initial(features["fuzzy"]))
+	features["fuzzy"] = sanitize_integer(features["fuzzy"], 0, SCALED_MODES_COUNT - 1, initial(features["fuzzy"]))
 
 	hair_style = sanitize_inlist(hair_style, GLOB.hair_styles_list)
 	facial_hair_style = sanitize_inlist(facial_hair_style, GLOB.facial_hair_styles_list)
@@ -2199,7 +2199,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	directory_erptag		= sanitize_inlist(directory_erptag, GLOB.char_directory_erptags, initial(directory_erptag))
 	directory_gendertag		= sanitize_inlist(directory_gendertag, GLOB.char_directory_gendertags, initial(directory_gendertag))
 	directory_ad			= strip_html_simple(directory_ad, MAX_FLAVOR_LEN)
-	fuzzy 					= sanitize_integer(fuzzy, 0, 1, initial(fuzzy))
+	fuzzy 					= sanitize_integer(fuzzy, 0, SCALED_MODES_COUNT - 1, initial(fuzzy))
 	custom_blood_color 		= sanitize_integer(custom_blood_color, 0, 1, initial(custom_blood_color))
 	blood_color 			= sanitize_hexcolor(blood_color, 6, 1, initial(blood_color))
 

--- a/code/modules/client/preferences_ui.dm
+++ b/code/modules/client/preferences_ui.dm
@@ -275,35 +275,10 @@ datum/preferences/proc/ShowChoices(mob/user, skip_preview_update = FALSE)
 			dat += "<input type='range' class='csetup-zoom-slider' min='100' max='200' step='10' value='[preview_zoom]' onchange=\"window.location.href='?_src_=prefs;preference=preview_zoom;level='+this.value\">"
 			dat += "<a class='csetup-zoom-btn[preview_show_reference ? " linkOn" : ""]' href='?_src_=prefs;preference=preview_reference'>[T("preview_reference")]</a>"
 			dat += "</div>"
-			// Preview area: side-by-side when reference is on
-			var/has_reference = preview_show_reference && LAZYACCESS(preview_reference_cache, "[preview_direction]")
-			var/body_size_pct = round(features["body_size"] * 100)
-			if(has_reference)
-				dat += "<div class='csetup-preview-compare'>"
-				// Reference (100%) on the left
-				dat += "<div class='csetup-preview-half'>"
-				dat += "<div class='csetup-preview-inner' style='transform: scale([zoom_scale]); transform-origin: bottom center;'>"
-				dat += preview_reference_cache["[preview_direction]"]
-				dat += "</div>"
-				dat += "<div class='csetup-size-label'>100%</div>"
-				dat += "</div>"
-				// Character (actual size) on the right
-				dat += "<div class='csetup-preview-half'>"
-				dat += "<div class='csetup-preview-inner' style='transform: scale([zoom_scale]); transform-origin: bottom center;'>"
-				if(preview_icon64)
-					dat += preview_icon64
-				dat += "</div>"
-				dat += "<div class='csetup-size-label'>[body_size_pct]%</div>"
-				dat += "</div>"
-				dat += "</div>"
-			else
-				dat += "<div class='csetup-preview-img'>"
-				dat += "<div class='csetup-preview-inner' style='transform: scale([zoom_scale]); transform-origin: bottom center;'>"
-				if(preview_icon64)
-					dat += preview_icon64
-				dat += "</div>"
-				dat += "<div class='csetup-size-label'>[body_size_pct]%</div>"
-				dat += "</div>"
+			// Preview area — wrapped in span#char_preview for targeted updates
+			dat += "<span id='char_preview'>"
+			dat += build_preview_html()
+			dat += "</span>"
 
 			// ── Slot panel ──
 			if(path)
@@ -820,7 +795,15 @@ datum/preferences/proc/ShowChoices(mob/user, skip_preview_update = FALSE)
 
 							dat += "<b>[T("body_size")]:</b> <a href='?_src_=prefs;preference=body_size;task=input'>[features["body_size"]*100]%</a><br>"
 							dat += "<b>[T("normalized_size")]:</b> <a href='?_src_=prefs;preference=normalized_size;task=input'>[features["normalized_size"]*100]%</a><br>"
-							var/fuzzy_display = (fuzzy == SCALED_FUZZY) ? fuzzy_label : sharp_label
+							var/parts_label = T("parts")
+							var/fuzzy_display
+							switch(fuzzy)
+								if(SCALED_SHARP)
+									fuzzy_display = sharp_label
+								if(SCALED_FUZZY)
+									fuzzy_display = fuzzy_label
+								if(SCALED_PARTS)
+									fuzzy_display = parts_label
 							dat += "<b>[T("scaled_appearance")]:</b> <a href='?_src_=prefs;preference=toggle_fuzzy;task=input'>[fuzzy_display]</a><br>"
 							dat += "<b>[T("weight")]:</b> <a href='?_src_=prefs;preference=body_weight;task=input'>[all_quirks.Find("Пожиратель") ? NAME_WEIGHT_NORMAL : body_weight]</a><br>" //BLUEMOON ADD вес персонажей
 
@@ -1981,10 +1964,52 @@ datum/preferences/proc/ShowChoices(mob/user, skip_preview_update = FALSE)
 	if(loadout_sheet)
 		popup.add_stylesheet(loadout_sheet)
 		popup.add_stylesheet("preferences_modern", 'html/browser/preferences_modern.css')
-		popup.add_script("prefs_state", 'html/browser/prefs_state.js')
+	popup.add_script("prefs_state", 'html/browser/prefs_state.js')
 	popup.set_content(dat.Join())
 	popup.open(FALSE)
 	onclose(user, "preferences_window", src)
+
+/// Builds just the preview image HTML (for use in both full ShowChoices and targeted updates)
+/datum/preferences/proc/build_preview_html()
+	var/list/preview_dat = list()
+	var/zoom_scale = preview_zoom * 0.01
+	var/has_reference = preview_show_reference && LAZYACCESS(preview_reference_cache, "[preview_direction]")
+	var/body_size_pct = round(features["body_size"] * 100)
+	if(has_reference)
+		preview_dat += "<div class='csetup-preview-compare'>"
+		// Reference (100%) on the left
+		preview_dat += "<div class='csetup-preview-half'>"
+		preview_dat += "<div class='csetup-preview-inner' style='transform: scale([zoom_scale]); transform-origin: bottom center;'>"
+		preview_dat += preview_reference_cache["[preview_direction]"]
+		preview_dat += "</div>"
+		preview_dat += "<div class='csetup-size-label'>100%</div>"
+		preview_dat += "</div>"
+		// Character (actual size) on the right
+		preview_dat += "<div class='csetup-preview-half'>"
+		preview_dat += "<div class='csetup-preview-inner' style='transform: scale([zoom_scale]); transform-origin: bottom center;'>"
+		if(preview_icon64)
+			preview_dat += preview_icon64
+		preview_dat += "</div>"
+		preview_dat += "<div class='csetup-size-label'>[body_size_pct]%</div>"
+		preview_dat += "</div>"
+		preview_dat += "</div>"
+	else
+		preview_dat += "<div class='csetup-preview-img'>"
+		preview_dat += "<div class='csetup-preview-inner' style='transform: scale([zoom_scale]); transform-origin: bottom center;'>"
+		if(preview_icon64)
+			preview_dat += preview_icon64
+		preview_dat += "</div>"
+		preview_dat += "<div class='csetup-size-label'>[body_size_pct]%</div>"
+		preview_dat += "</div>"
+	return preview_dat.Join()
+
+/// Updates only the preview image in the browser, without rebuilding the entire ShowChoices HTML.
+/// Uses JS function update_char_preview() injected via prefs_state.js or inline script.
+/datum/preferences/proc/update_preview_html_only(mob/user)
+	if(!user?.client)
+		return
+	var/preview_html = build_preview_html()
+	user << output(preview_html, "preferences_browser.browser:update_char_preview")
 
 /datum/preferences/proc/cycle_character_creation_modern_accent()
 	if(!findtext(charcreation_theme, "modern"))

--- a/code/modules/client/preferences_ui.dm
+++ b/code/modules/client/preferences_ui.dm
@@ -268,10 +268,42 @@ datum/preferences/proc/ShowChoices(mob/user, skip_preview_update = FALSE)
 			dat += "<a class='csetup-preview-btn[preview_pref == PREVIEW_PREF_NAKED ? " linkOn" : ""]' href='?_src_=prefs;preference=character_preview;tab=[PREVIEW_PREF_NAKED]'>[T("preview_naked")]</a>"
 			dat += "<a class='csetup-preview-btn[preview_pref == PREVIEW_PREF_NAKED_AROUSED ? " linkOn" : ""]' href='?_src_=prefs;preference=character_preview;tab=[PREVIEW_PREF_NAKED_AROUSED]'>[T("preview_naked_aroused")]</a>"
 			dat += "</div>"
-			dat += "<div class='csetup-preview-img'>"
-			if(preview_icon64)
-				dat += preview_icon64
+			// Zoom slider + reference toggle
+			var/zoom_scale = preview_zoom * 0.01
+			dat += "<div class='csetup-zoom-bar'>"
+			dat += "<span class='csetup-zoom-label'>[preview_zoom]%</span>"
+			dat += "<input type='range' class='csetup-zoom-slider' min='100' max='200' step='10' value='[preview_zoom]' onchange=\"window.location.href='?_src_=prefs;preference=preview_zoom;level='+this.value\">"
+			dat += "<a class='csetup-zoom-btn[preview_show_reference ? " linkOn" : ""]' href='?_src_=prefs;preference=preview_reference'>[T("preview_reference")]</a>"
 			dat += "</div>"
+			// Preview area: side-by-side when reference is on
+			var/has_reference = preview_show_reference && LAZYACCESS(preview_reference_cache, "[preview_direction]")
+			var/body_size_pct = round(features["body_size"] * 100)
+			if(has_reference)
+				dat += "<div class='csetup-preview-compare'>"
+				// Reference (100%) on the left
+				dat += "<div class='csetup-preview-half'>"
+				dat += "<div class='csetup-preview-inner' style='transform: scale([zoom_scale]); transform-origin: bottom center;'>"
+				dat += preview_reference_cache["[preview_direction]"]
+				dat += "</div>"
+				dat += "<div class='csetup-size-label'>100%</div>"
+				dat += "</div>"
+				// Character (actual size) on the right
+				dat += "<div class='csetup-preview-half'>"
+				dat += "<div class='csetup-preview-inner' style='transform: scale([zoom_scale]); transform-origin: bottom center;'>"
+				if(preview_icon64)
+					dat += preview_icon64
+				dat += "</div>"
+				dat += "<div class='csetup-size-label'>[body_size_pct]%</div>"
+				dat += "</div>"
+				dat += "</div>"
+			else
+				dat += "<div class='csetup-preview-img'>"
+				dat += "<div class='csetup-preview-inner' style='transform: scale([zoom_scale]); transform-origin: bottom center;'>"
+				if(preview_icon64)
+					dat += preview_icon64
+				dat += "</div>"
+				dat += "<div class='csetup-size-label'>[body_size_pct]%</div>"
+				dat += "</div>"
 
 			// ── Slot panel ──
 			if(path)
@@ -450,6 +482,8 @@ datum/preferences/proc/ShowChoices(mob/user, skip_preview_update = FALSE)
 				if(islist(chosen_gear))
 					loadout_errors = 0
 					for(var/loadout_item in chosen_gear)
+						if(!islist(loadout_item))
+							continue
 						var/loadout_item_path = loadout_item[LOADOUT_ITEM]
 						if(loadout_item_path)
 							var/datum/gear/loadout_gear = text2path(loadout_item_path)
@@ -786,7 +820,8 @@ datum/preferences/proc/ShowChoices(mob/user, skip_preview_update = FALSE)
 
 							dat += "<b>[T("body_size")]:</b> <a href='?_src_=prefs;preference=body_size;task=input'>[features["body_size"]*100]%</a><br>"
 							dat += "<b>[T("normalized_size")]:</b> <a href='?_src_=prefs;preference=normalized_size;task=input'>[features["normalized_size"]*100]%</a><br>"
-							dat += "<b>[T("scaled_appearance")]:</b> <a href='?_src_=prefs;preference=toggle_fuzzy;task=input'>[fuzzy ? fuzzy_label : sharp_label]</a><br>"
+							var/fuzzy_display = (fuzzy == SCALED_FUZZY) ? fuzzy_label : sharp_label
+							dat += "<b>[T("scaled_appearance")]:</b> <a href='?_src_=prefs;preference=toggle_fuzzy;task=input'>[fuzzy_display]</a><br>"
 							dat += "<b>[T("weight")]:</b> <a href='?_src_=prefs;preference=body_weight;task=input'>[all_quirks.Find("Пожиратель") ? NAME_WEIGHT_NORMAL : body_weight]</a><br>" //BLUEMOON ADD вес персонажей
 
 						if(!(NOEYES in pref_species.species_traits))
@@ -1490,21 +1525,22 @@ datum/preferences/proc/ShowChoices(mob/user, skip_preview_update = FALSE)
 								dat += "<td><font size=2><b>Data contained</b></font></td></tr>"
 								dat += "</center>"
 								var/list/sanitize_current_slot = loadout_data["SAVE_[loadout_slot]"]
-								for(var/list/entry in sanitize_current_slot)
-									var/test_item = entry["loadout_item"]
-									if(text2path(test_item))
-										continue
-									var/background_cl = "#23273C"
-									if(even)
-										background_cl = "#17191C"
-									even = !even
-									var/test_item_display = test_item ? test_item : "no path!!?! Report to an admin!"
-									var/encoded_test_item = url_encode(test_item ? test_item : "")
-									dat += "<tr style='vertical-align:top; background-color: [background_cl];'><td width=15%><a style='white-space:normal;' href='?_src_=prefs;preference=gear;clear_invalid_gear=[encoded_test_item];'>[test_item_display]</a></td>"
-									dat += "<td style='vertical-align:top'>"
-									var/list/other_data = entry["loadout_item"] ? entry - "loadout_item" : entry
-									dat += json_encode(other_data)
-									dat += "</td></tr>"
+								if(islist(sanitize_current_slot))
+									for(var/list/entry in sanitize_current_slot)
+										var/test_item = entry["loadout_item"]
+										if(text2path(test_item))
+											continue
+										var/background_cl = "#23273C"
+										if(even)
+											background_cl = "#17191C"
+										even = !even
+										var/test_item_display = test_item ? test_item : "no path!!?! Report to an admin!"
+										var/encoded_test_item = url_encode(test_item ? test_item : "")
+										dat += "<tr style='vertical-align:top; background-color: [background_cl];'><td width=15%><a style='white-space:normal;' href='?_src_=prefs;preference=gear;clear_invalid_gear=[encoded_test_item];'>[test_item_display]</a></td>"
+										dat += "<td style='vertical-align:top'>"
+										var/list/other_data = entry["loadout_item"] ? entry - "loadout_item" : entry
+										dat += json_encode(other_data)
+										dat += "</td></tr>"
 					dat += "</table>"
 			dat += "</div>" // end csetup-settings-content
 			dat += "</div>" // end csetup-settings-wrap

--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -36,12 +36,26 @@
 	if(preview_generating)
 		pending_preview_update = TRUE
 		return
+	preview_generating = TRUE
 	INVOKE_ASYNC(src, PROC_REF(_generate_preview_icon))
+
+/// Освобождает персистентный манекен превью. Вызывать при закрытии меню настроек.
+/datum/preferences/proc/release_preview_mannequin()
+	if(preview_mannequin)
+		unset_busy_human_dummy("preview_mannequin_[REF(src)]")
+		preview_mannequin = null
+	preview_mannequin_initialized = FALSE
+
+/// Инвалидирует персистентный манекен — при следующем обновлении будет полная пересборка.
+/// Вызывать при смене species, gender, body_type и других "тяжёлых" изменений.
+/datum/preferences/proc/invalidate_preview_mannequin()
+	preview_mannequin_initialized = FALSE
+	preview_change_hint = null
 
 /datum/preferences/proc/_generate_preview_icon()
 	if(QDELETED(src))
+		preview_generating = FALSE
 		return
-	preview_generating = TRUE
 	var/datum/job/previewJob = get_highest_job()
 
 	if(previewJob)
@@ -57,7 +71,10 @@
 			pending_preview_update = FALSE
 			var/mob/user = parent?.mob
 			if(user)
-				ShowChoices(user, skip_preview_update = !had_pending_ai)
+				if(had_pending_ai)
+					update_preview_icon()
+				else
+					update_preview_html_only(user)
 			return
 		if(istype(previewJob,/datum/job/cyborg))
 			LAZYINITLIST(preview_dir_cache)
@@ -70,68 +87,96 @@
 			pending_preview_update = FALSE
 			var/mob/user = parent?.mob
 			if(user)
-				ShowChoices(user, skip_preview_update = !had_pending_cyborg)
+				if(had_pending_cyborg)
+					update_preview_icon()
+				else
+					update_preview_html_only(user)
 			return
 
-	// Set up the dummy for its photoshoot
-	var/mob/living/carbon/human/dummy/mannequin = generate_or_wait_for_human_dummy(DUMMY_HUMAN_SLOT_PREFERENCES)
-	if(!mannequin)
-		preview_generating = FALSE
-		return
-	copy_to(mannequin, initial_spawn = TRUE)
+	// --- Персистентный манекен: избегаем copy_to() + regenerate_icons() при каждом клике ---
+	var/slot_key = "preview_mannequin_[REF(src)]"
+	var/current_hint = preview_change_hint
+	preview_change_hint = null // Очищаем, чтобы следующий вызов без hint шёл полным путём
 
-	// Reset size to default for preview — body_size distorts getFlatIcon canvas, making large characters tiny
-	var/current_size = get_size(mannequin)
-	if(current_size != RESIZE_DEFAULT_SIZE)
-		mannequin.update_size(RESIZE_DEFAULT_SIZE, current_size)
+	if(preview_mannequin_initialized && !QDELETED(preview_mannequin) && current_hint)
+		// Инкрементальный путь: обновляем только нужные слои на уже инициализированном манекене
+		switch(current_hint)
+			if(PREVIEW_HINT_HAIR)
+				preview_mannequin.hair_style = hair_style
+				preview_mannequin.hair_color = hair_color
+				preview_mannequin.facial_hair_style = facial_hair_style
+				preview_mannequin.facial_hair_color = facial_hair_color
+				preview_mannequin.grad_style = grad_style
+				preview_mannequin.grad_color = grad_color
+				preview_mannequin.update_hair()
+			if(PREVIEW_HINT_BODY)
+				copy_to(preview_mannequin, initial_spawn = TRUE)
+				preview_mannequin.update_body(TRUE)
+				preview_mannequin.update_hair()
+			if(PREVIEW_HINT_MUTANT_BODYPARTS)
+				copy_to(preview_mannequin, initial_spawn = TRUE)
+				preview_mannequin.update_body(TRUE)
+				preview_mannequin.update_mutant_bodyparts()
+				preview_mannequin.update_hair()
+			else
+				copy_to(preview_mannequin, initial_spawn = TRUE)
+				preview_mannequin.regenerate_icons()
+	else
+		// Полная инициализация — первый вызов или после инвалидации
+		if(QDELETED(preview_mannequin))
+			preview_mannequin = generate_or_wait_for_human_dummy(slot_key)
+		if(!preview_mannequin)
+			preview_generating = FALSE
+			return
+		copy_to(preview_mannequin, initial_spawn = TRUE)
 
-	switch(preview_pref)
-		if(PREVIEW_PREF_JOB)
-			if(previewJob)
-				mannequin.job = previewJob.title
-				previewJob.equip(mannequin, TRUE, preference_source = parent)
-		if(PREVIEW_PREF_LOADOUT)
-			var/mob/preview_src_mob = parent?.mob
-			if(preview_src_mob)
-				SSjob.equip_loadout(preview_src_mob, mannequin, bypass_prereqs = TRUE, can_drop = FALSE, is_dummy = TRUE)
-				SSjob.post_equip_loadout(preview_src_mob, mannequin, bypass_prereqs = TRUE, can_drop = FALSE, is_dummy = TRUE)
-		if(PREVIEW_PREF_NAKED)
-			/*
-			mannequin.hidden_underwear = TRUE
-			mannequin.hidden_undershirt = TRUE
-			mannequin.hidden_socks = TRUE
-			*/
-		if(PREVIEW_PREF_NAKED_AROUSED)
-			/*
-			mannequin.hidden_underwear = TRUE
-			mannequin.hidden_undershirt = TRUE
-			mannequin.hidden_socks = TRUE
-			*/
-			for(var/obj/item/organ/genital/genital in mannequin.internal_organs)
-				if(CHECK_BITFIELD(genital.genital_flags, GENITAL_CAN_AROUSE))
-					genital.set_aroused_state(TRUE, null)
+		// Reset size to default for preview — body_size distorts getFlatIcon canvas, making large characters tiny
+		var/current_size = get_size(preview_mannequin)
+		if(current_size != RESIZE_DEFAULT_SIZE)
+			preview_mannequin.update_size(RESIZE_DEFAULT_SIZE, current_size)
 
-	mannequin.regenerate_icons()
+		switch(preview_pref)
+			if(PREVIEW_PREF_JOB)
+				if(previewJob)
+					preview_mannequin.job = previewJob.title
+					previewJob.equip(preview_mannequin, TRUE, preference_source = parent)
+			if(PREVIEW_PREF_LOADOUT)
+				var/mob/preview_src_mob = parent?.mob
+				if(preview_src_mob)
+					SSjob.equip_loadout(preview_src_mob, preview_mannequin, bypass_prereqs = TRUE, can_drop = FALSE, is_dummy = TRUE)
+					SSjob.post_equip_loadout(preview_src_mob, preview_mannequin, bypass_prereqs = TRUE, can_drop = FALSE, is_dummy = TRUE)
+			if(PREVIEW_PREF_NAKED)
+				pass()
+			if(PREVIEW_PREF_NAKED_AROUSED)
+				for(var/obj/item/organ/genital/genital in preview_mannequin.internal_organs)
+					if(CHECK_BITFIELD(genital.genital_flags, GENITAL_CAN_AROUSE))
+						genital.set_aroused_state(TRUE, null)
 
-	// Генерируем иконки для всех 4 направлений разом, чтобы повороты были мгновенными
+		preview_mannequin.regenerate_icons()
+		preview_mannequin_initialized = TRUE
+
+	var/mob/living/carbon/human/dummy/mannequin = preview_mannequin
+
 	// Размер персонажа отображается через DM icon.Scale() + размещение на фиксированном canvas 64x64.
 	// Canvas 64px → CSS 320px = чистый 5x upscale без субпиксельных артефактов.
-	// При size 1.0: персонаж 32px на canvas 64px = 50% превью (160px на экране).
-	// При size 2.0: 64px заполняет canvas. При size 3.0+: обрезается сверху (как в игре).
 	var/preview_body_size = features["body_size"] || RESIZE_DEFAULT_SIZE
 	var/visual_scale = clamp(preview_body_size, 0.25, 3)
 	var/canvas_size = 64
 	var/is_fuzzy = (fuzzy == SCALED_FUZZY)
+	var/is_parts = (fuzzy == SCALED_PARTS) // WIP: per-part скейлинг не доработан, тестовый режим
+
+	// Per-Part: применяем размер на манекен — оверлеи скейлятся по частям через apply_overlay,
+	// getFlatIcon захватит уже отмасштабированный результат
+	if(is_parts && visual_scale != RESIZE_DEFAULT_SIZE)
+		mannequin.update_size(visual_scale, RESIZE_DEFAULT_SIZE)
 
 	// Fuzzy при нестандартном размере: CSS делает bilinear scale напрямую из исходных пикселей
-	// (как BYOND без PIXEL_SCALE — масштабирует bilinear, а не nearest-neighbor)
 	var/scale_prefix
 	if(is_fuzzy && visual_scale != RESIZE_DEFAULT_SIZE)
 		scale_prefix = "<img style='image-rendering: smooth; image-rendering: auto; transform: scale([visual_scale]); transform-origin: bottom center;' "
 
 	LAZYCLEARLIST(preview_dir_cache)
 	LAZYINITLIST(preview_dir_cache)
-	// Reference переиспользует тот же getFlatIcon до масштабирования (манекен уже при 100%)
 	var/build_reference = preview_show_reference
 	if(build_reference)
 		LAZYCLEARLIST(preview_reference_cache)
@@ -139,44 +184,66 @@
 	else
 		LAZYCLEARLIST(preview_reference_cache)
 
-	for(var/dir in GLOB.cardinals)
-		var/icon/flat = getFlatIcon(mannequin, defdir = dir, no_anim = TRUE)
-		if(flat)
-			// Reference: копируем иконку ДО масштабирования — это и есть 100%
-			if(build_reference)
-				var/icon/ref_flat = icon(flat)
-				var/rfw = ref_flat.Width()
-				var/ref_crop_x1 = 1 - round((canvas_size - rfw) / 2)
-				ref_flat.Crop(ref_crop_x1, 1, ref_crop_x1 + canvas_size - 1, canvas_size)
-				preview_reference_cache["[dir]"] = icon2html(ref_flat, parent)
-			// Sharp: масштабируем в DM nearest-neighbor (как PIXEL_SCALE в игре)
-			// Fuzzy: оставляем оригинальный размер — CSS сделает bilinear через transform
-			if(!is_fuzzy && visual_scale != RESIZE_DEFAULT_SIZE)
-				flat.Scale(max(1, round(flat.Width() * visual_scale)), max(1, round(flat.Height() * visual_scale)))
-			// Размещаем на canvas 64x64: bottom-center (ноги на земле, как в игре)
-			var/fw = flat.Width()
-			var/crop_x1 = 1 - round((canvas_size - fw) / 2)
-			flat.Crop(crop_x1, 1, crop_x1 + canvas_size - 1, canvas_size)
-
-			var/raw_html = icon2html(flat, parent)
-			if(scale_prefix)
-				preview_dir_cache["[dir]"] = replacetext(raw_html, "<img ", scale_prefix)
-			else
-				preview_dir_cache["[dir]"] = raw_html
-		else
-			preview_dir_cache["[dir]"] = null
-			if(build_reference)
-				preview_reference_cache["[dir]"] = null
-
+	// Сначала генерируем только текущее направление — мгновенный отклик для пользователя
+	_generate_preview_for_dir(mannequin, preview_direction, canvas_size, visual_scale, is_fuzzy, is_parts, scale_prefix, build_reference)
 	preview_icon64 = preview_dir_cache["[preview_direction]"]
-	unset_busy_human_dummy(DUMMY_HUMAN_SLOT_PREFERENCES)
+
+	// Показываем результат сразу, не дожидаясь остальных 3 направлений
+	// Используем targeted output — обновляем ТОЛЬКО превью, не пересоздавая 2500+ строк HTML
+	var/mob/user = parent?.mob
+	if(user)
+		update_preview_html_only(user)
+
+	// Догенерируем остальные 3 направления в фоне (для мгновенных поворотов)
+	for(var/dir in GLOB.cardinals)
+		if(dir == preview_direction)
+			continue
+		// Если пришёл новый запрос на обновление — прерываем, актуальные данные пересоздадутся
+		if(pending_preview_update)
+			break
+		_generate_preview_for_dir(mannequin, dir, canvas_size, visual_scale, is_fuzzy, is_parts, scale_prefix, build_reference)
+
+	// НЕ освобождаем манекен — он персистентный и переиспользуется при следующем обновлении
+	// Размер нужно сбросить если он менялся для рендера
+	if(is_parts && visual_scale != RESIZE_DEFAULT_SIZE)
+		mannequin.update_size(RESIZE_DEFAULT_SIZE, visual_scale)
 
 	preview_generating = FALSE
-	var/mob/user = parent?.mob
 	var/had_pending = pending_preview_update
 	pending_preview_update = FALSE
-	if(user)
-		ShowChoices(user, skip_preview_update = !had_pending)
+	if(had_pending && user)
+		update_preview_icon()
+
+/// Генерирует и кэширует превью-иконку для одного направления
+/datum/preferences/proc/_generate_preview_for_dir(mob/living/carbon/human/mannequin, dir, canvas_size, visual_scale, is_fuzzy, is_parts, scale_prefix, build_reference)
+	var/icon/flat = getFlatIcon(mannequin, defdir = dir, no_anim = TRUE)
+	if(!flat)
+		preview_dir_cache["[dir]"] = null
+		if(build_reference)
+			preview_reference_cache["[dir]"] = null
+		return
+	// Reference: копируем иконку ДО масштабирования — это и есть 100%
+	if(build_reference)
+		var/icon/ref_flat = icon(flat)
+		var/rfw = ref_flat.Width()
+		var/ref_crop_x1 = 1 - round((canvas_size - rfw) / 2)
+		ref_flat.Crop(ref_crop_x1, 1, ref_crop_x1 + canvas_size - 1, canvas_size)
+		preview_reference_cache["[dir]"] = icon2html(ref_flat, parent)
+	// Sharp: масштабируем в DM nearest-neighbor (как PIXEL_SCALE в игре)
+	// Fuzzy: оставляем оригинальный размер — CSS сделает bilinear через transform
+	// Parts: оверлеи уже отмасштабированы на манекене — пропускаем
+	if(!is_fuzzy && !is_parts && visual_scale != RESIZE_DEFAULT_SIZE)
+		flat.Scale(max(1, round(flat.Width() * visual_scale)), max(1, round(flat.Height() * visual_scale)))
+	// Размещаем на canvas 64x64: bottom-center (ноги на земле, как в игре)
+	var/fw = flat.Width()
+	var/crop_x1 = 1 - round((canvas_size - fw) / 2)
+	flat.Crop(crop_x1, 1, crop_x1 + canvas_size - 1, canvas_size)
+
+	var/raw_html = icon2html(flat, parent)
+	if(scale_prefix)
+		preview_dir_cache["[dir]"] = replacetext(raw_html, "<img ", scale_prefix)
+	else
+		preview_dir_cache["[dir]"] = raw_html
 
 /datum/preferences/proc/get_highest_job()
 	var/highest_pref = 0

--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -30,6 +30,9 @@
 	age = rand(AGE_MIN,AGE_MAX)
 
 /datum/preferences/proc/update_preview_icon()
+	// Сброс кэша направлений — внешность изменилась
+	preview_dir_cache = null
+	preview_reference_cache = null
 	if(preview_generating)
 		pending_preview_update = TRUE
 		return
@@ -44,8 +47,11 @@
 	if(previewJob)
 		// Silicons only need a very basic preview since there is no customization for them.
 		if(istype(previewJob,/datum/job/ai))
-			var/icon/ai_icon = icon('icons/mob/ai.dmi', icon_state = resolve_ai_icon(preferred_ai_core_display), dir = preview_direction)
-			preview_icon64 = icon2html(ai_icon, parent)
+			LAZYINITLIST(preview_dir_cache)
+			for(var/dir in GLOB.cardinals)
+				var/icon/ai_icon = icon('icons/mob/ai.dmi', icon_state = resolve_ai_icon(preferred_ai_core_display), dir = dir)
+				preview_dir_cache["[dir]"] = icon2html(ai_icon, parent)
+			preview_icon64 = preview_dir_cache["[preview_direction]"]
 			preview_generating = FALSE
 			var/had_pending_ai = pending_preview_update
 			pending_preview_update = FALSE
@@ -54,8 +60,11 @@
 				ShowChoices(user, skip_preview_update = !had_pending_ai)
 			return
 		if(istype(previewJob,/datum/job/cyborg))
-			var/icon/bot_icon = icon('icons/mob/robots.dmi', icon_state = "robot", dir = preview_direction)
-			preview_icon64 = icon2html(bot_icon, parent)
+			LAZYINITLIST(preview_dir_cache)
+			for(var/dir in GLOB.cardinals)
+				var/icon/bot_icon = icon('icons/mob/robots.dmi', icon_state = "robot", dir = dir)
+				preview_dir_cache["[dir]"] = icon2html(bot_icon, parent)
+			preview_icon64 = preview_dir_cache["[preview_direction]"]
 			preview_generating = FALSE
 			var/had_pending_cyborg = pending_preview_update
 			pending_preview_update = FALSE
@@ -70,6 +79,11 @@
 		preview_generating = FALSE
 		return
 	copy_to(mannequin, initial_spawn = TRUE)
+
+	// Reset size to default for preview — body_size distorts getFlatIcon canvas, making large characters tiny
+	var/current_size = get_size(mannequin)
+	if(current_size != RESIZE_DEFAULT_SIZE)
+		mannequin.update_size(RESIZE_DEFAULT_SIZE, current_size)
 
 	switch(preview_pref)
 		if(PREVIEW_PREF_JOB)
@@ -99,11 +113,62 @@
 
 	mannequin.regenerate_icons()
 
-	var/icon/flat = getFlatIcon(mannequin, defdir = preview_direction, no_anim = TRUE)
-	if(flat)
-		preview_icon64 = icon2html(flat, parent)
+	// Генерируем иконки для всех 4 направлений разом, чтобы повороты были мгновенными
+	// Размер персонажа отображается через DM icon.Scale() + размещение на фиксированном canvas 64x64.
+	// Canvas 64px → CSS 320px = чистый 5x upscale без субпиксельных артефактов.
+	// При size 1.0: персонаж 32px на canvas 64px = 50% превью (160px на экране).
+	// При size 2.0: 64px заполняет canvas. При size 3.0+: обрезается сверху (как в игре).
+	var/preview_body_size = features["body_size"] || RESIZE_DEFAULT_SIZE
+	var/visual_scale = clamp(preview_body_size, 0.25, 3)
+	var/canvas_size = 64
+	var/is_fuzzy = (fuzzy == SCALED_FUZZY)
+
+	// Fuzzy при нестандартном размере: CSS делает bilinear scale напрямую из исходных пикселей
+	// (как BYOND без PIXEL_SCALE — масштабирует bilinear, а не nearest-neighbor)
+	var/scale_prefix
+	if(is_fuzzy && visual_scale != RESIZE_DEFAULT_SIZE)
+		scale_prefix = "<img style='image-rendering: smooth; image-rendering: auto; transform: scale([visual_scale]); transform-origin: bottom center;' "
+
+	LAZYCLEARLIST(preview_dir_cache)
+	LAZYINITLIST(preview_dir_cache)
+	// Reference переиспользует тот же getFlatIcon до масштабирования (манекен уже при 100%)
+	var/build_reference = preview_show_reference
+	if(build_reference)
+		LAZYCLEARLIST(preview_reference_cache)
+		LAZYINITLIST(preview_reference_cache)
 	else
-		preview_icon64 = null
+		LAZYCLEARLIST(preview_reference_cache)
+
+	for(var/dir in GLOB.cardinals)
+		var/icon/flat = getFlatIcon(mannequin, defdir = dir, no_anim = TRUE)
+		if(flat)
+			// Reference: копируем иконку ДО масштабирования — это и есть 100%
+			if(build_reference)
+				var/icon/ref_flat = icon(flat)
+				var/rfw = ref_flat.Width()
+				var/ref_crop_x1 = 1 - round((canvas_size - rfw) / 2)
+				ref_flat.Crop(ref_crop_x1, 1, ref_crop_x1 + canvas_size - 1, canvas_size)
+				preview_reference_cache["[dir]"] = icon2html(ref_flat, parent)
+			// Sharp: масштабируем в DM nearest-neighbor (как PIXEL_SCALE в игре)
+			// Fuzzy: оставляем оригинальный размер — CSS сделает bilinear через transform
+			if(!is_fuzzy && visual_scale != RESIZE_DEFAULT_SIZE)
+				flat.Scale(max(1, round(flat.Width() * visual_scale)), max(1, round(flat.Height() * visual_scale)))
+			// Размещаем на canvas 64x64: bottom-center (ноги на земле, как в игре)
+			var/fw = flat.Width()
+			var/crop_x1 = 1 - round((canvas_size - fw) / 2)
+			flat.Crop(crop_x1, 1, crop_x1 + canvas_size - 1, canvas_size)
+
+			var/raw_html = icon2html(flat, parent)
+			if(scale_prefix)
+				preview_dir_cache["[dir]"] = replacetext(raw_html, "<img ", scale_prefix)
+			else
+				preview_dir_cache["[dir]"] = raw_html
+		else
+			preview_dir_cache["[dir]"] = null
+			if(build_reference)
+				preview_reference_cache["[dir]"] = null
+
+	preview_icon64 = preview_dir_cache["[preview_direction]"]
 	unset_busy_human_dummy(DUMMY_HUMAN_SLOT_PREFERENCES)
 
 	preview_generating = FALSE

--- a/code/modules/mob/living/carbon/carbon_update_icons.dm
+++ b/code/modules/mob/living/carbon/carbon_update_icons.dm
@@ -1,14 +1,39 @@
 /mob/living/carbon
 	var/list/overlays_standing[TOTAL_LAYERS]
+	/// Tracks the actually-added (possibly scaled) overlays for correct removal in per-part mode
+	var/list/overlays_applied[TOTAL_LAYERS]
 
 /mob/living/carbon/proc/apply_overlay(cache_index)
 	if((. = overlays_standing[cache_index]))
+		if(fuzzy == SCALED_PARTS && current_body_scale != 1)
+			. = scale_overlays_for_parts(., current_body_scale)
+		overlays_applied[cache_index] = .
 		add_overlay(.)
 
+/// Scales overlay(s) for per-part scaling mode. Accepts single appearance or list. WIP: тестовый режим, не доработан.
+/mob/living/carbon/proc/scale_overlays_for_parts(overlays_data, scale)
+	if(islist(overlays_data))
+		var/list/result = list()
+		for(var/entry in overlays_data)
+			result += scale_single_overlay(entry, scale)
+		return result
+	return scale_single_overlay(overlays_data, scale)
+
+/// Scales a single overlay appearance for per-part mode: applies transform and adjusts offsets.
+/mob/living/carbon/proc/scale_single_overlay(mutable_appearance/original, scale)
+	var/mutable_appearance/scaled = new(original)
+	scaled.pixel_x = round(original.pixel_x * scale)
+	scaled.pixel_y = round(original.pixel_y * scale + 16 * (scale - 1))
+	var/matrix/M = matrix(original.transform)
+	M.Scale(scale)
+	scaled.transform = M
+	return scaled
+
 /mob/living/carbon/proc/remove_overlay(cache_index)
-	var/I = overlays_standing[cache_index]
+	var/I = overlays_applied[cache_index]
 	if(I)
 		cut_overlay(I)
+		overlays_applied[cache_index] = null
 		overlays_standing[cache_index] = null
 
 /mob/living/carbon/regenerate_icons()

--- a/code/modules/mob/living/living_update_icons.dm
+++ b/code/modules/mob/living/living_update_icons.dm
@@ -1,10 +1,14 @@
 //IMPORTANT: Multiple animate() calls do not stack well, so try to do them all at once if you can.
 /mob/living/update_transform(do_animate = TRUE)
-//BLUEMOOB ADD START - FUZZY
-	appearance_flags |= PIXEL_SCALE
-	if(fuzzy)
-		appearance_flags &= ~PIXEL_SCALE
-//BLUEMOON ADD END - FUZZY
+//BLUEMOON ADD START - SCALED APPEARANCE
+	switch(fuzzy)
+		if(SCALED_SHARP)
+			appearance_flags |= PIXEL_SCALE
+			ADD_KEEP_TOGETHER(src, SCALED_APPEARANCE_TRAIT)
+		if(SCALED_FUZZY)
+			appearance_flags &= ~PIXEL_SCALE
+			ADD_KEEP_TOGETHER(src, SCALED_APPEARANCE_TRAIT)
+//BLUEMOON ADD END - SCALED APPEARANCE
 	var/matrix/ntransform = matrix(transform) //aka transform.Copy()
 	var/final_pixel_y = pixel_y
 	var/changed = 0

--- a/code/modules/mob/living/living_update_icons.dm
+++ b/code/modules/mob/living/living_update_icons.dm
@@ -8,6 +8,9 @@
 		if(SCALED_FUZZY)
 			appearance_flags &= ~PIXEL_SCALE
 			ADD_KEEP_TOGETHER(src, SCALED_APPEARANCE_TRAIT)
+		if(SCALED_PARTS) // WIP: тестовый режим, не доработан
+			appearance_flags &= ~PIXEL_SCALE
+			ADD_KEEP_TOGETHER(src, SCALED_APPEARANCE_TRAIT)
 //BLUEMOON ADD END - SCALED APPEARANCE
 	var/matrix/ntransform = matrix(transform) //aka transform.Copy()
 	var/final_pixel_y = pixel_y
@@ -25,13 +28,23 @@
 					setDir(pick(NORTH, SOUTH)) //So you fall on your side rather than your face or ass
 
 	if(resize != RESIZE_DEFAULT_SIZE)
-		changed++
-		ntransform.Scale(resize)
-		if(lying && rotate_on_lying)
-			ntransform.Translate(lying == 90 ? 16*(resize-1) : -(16*(resize-1)), 0) //Makes sure you stand on the tile no matter the size - sand
+		if(fuzzy == SCALED_PARTS) // WIP: тестовый режим, не доработан
+			// Per-part mode: don't scale the mob matrix, track scale for overlay application
+			current_body_scale *= resize
+			resize = RESIZE_DEFAULT_SIZE
+			// Rebuild all overlays with new per-part scale
+			if(iscarbon(src))
+				var/mob/living/carbon/C = src
+				C.regenerate_icons()
 		else
-			ntransform.Translate(0, 16*(resize-1)) //Makes sure you stand on the tile no matter the size - sand
-		resize = RESIZE_DEFAULT_SIZE
+			changed++
+			ntransform.Scale(resize)
+			current_body_scale *= resize
+			if(lying && rotate_on_lying)
+				ntransform.Translate(lying == 90 ? 16*(resize-1) : -(16*(resize-1)), 0) //Makes sure you stand on the tile no matter the size - sand
+			else
+				ntransform.Translate(0, 16*(resize-1)) //Makes sure you stand on the tile no matter the size - sand
+			resize = RESIZE_DEFAULT_SIZE
 
 	if(changed)
 		if(do_animate)

--- a/html/browser/preferences_modern.css
+++ b/html/browser/preferences_modern.css
@@ -1686,6 +1686,7 @@ body {
 /* Canvas preview image — replaces MAP element */
 .csetup-root.csetup-theme-modern .csetup-preview-img,
 .csetup-root.csetup-theme-classic .csetup-preview-img {
+	position: relative;
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -1705,6 +1706,93 @@ body {
 	width: 100%;
 	height: 100%;
 	object-fit: contain;
+}
+
+/* Preview inner wrapper for zoom transform (avoids conflict with fuzzy inline transform on img) */
+/* align-items: flex-end — привязка к низу, чтобы transform-origin: bottom center
+   на fuzzy img и zoom wrapper давали одинаковый якорь */
+.csetup-root .csetup-preview-inner {
+	width: 100%;
+	height: 100%;
+	display: flex;
+	align-items: flex-end;
+	justify-content: center;
+}
+
+/* Side-by-side comparison mode */
+.csetup-root.csetup-theme-modern .csetup-preview-compare,
+.csetup-root.csetup-theme-classic .csetup-preview-compare {
+	display: flex;
+	width: 320px;
+	height: 320px;
+	min-height: 320px;
+	flex-shrink: 0;
+	background: var(--csetup-bg, #121212);
+	border-bottom: 1px solid var(--csetup-border, #2f2f2f);
+	overflow: hidden;
+}
+.csetup-root .csetup-preview-half {
+	position: relative;
+	flex: 1 1 0;
+	overflow: hidden;
+	display: flex;
+	align-items: flex-end;
+	justify-content: center;
+}
+.csetup-root .csetup-preview-half + .csetup-preview-half {
+	border-left: 1px solid var(--csetup-border, #2f2f2f);
+}
+/* width:100% без height — img сохраняет квадратный aspect ratio (64x64),
+   flex-end прижимает к низу. transform-origin: bottom center на fuzzy img
+   теперь ссылается на реальный низ картинки, а не на низ растянутого элемента */
+.csetup-root .csetup-preview-half img {
+	image-rendering: pixelated;
+	image-rendering: crisp-edges;
+	width: 100%;
+}
+
+/* Size label overlay */
+.csetup-root .csetup-size-label {
+	position: absolute;
+	bottom: 4px;
+	right: 6px;
+	font-size: 11px;
+	color: rgba(255, 255, 255, 0.6);
+	background: rgba(0, 0, 0, 0.4);
+	padding: 1px 5px;
+	border-radius: 3px;
+	pointer-events: none;
+	z-index: 2;
+}
+
+/* Zoom toolbar */
+.csetup-root.csetup-theme-modern .csetup-zoom-bar,
+.csetup-root.csetup-theme-classic .csetup-zoom-bar {
+	display: flex;
+	gap: 4px;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
+	padding: 2px 4px;
+}
+.csetup-root .csetup-zoom-label {
+	font-size: 10px;
+	color: rgba(255, 255, 255, 0.5);
+	min-width: 30px;
+	text-align: center;
+}
+.csetup-root .csetup-zoom-slider {
+	flex: 1;
+	height: 14px;
+	cursor: pointer;
+	accent-color: var(--csetup-accent, #4a9eed);
+}
+.csetup-root.csetup-theme-modern a.csetup-zoom-btn,
+.csetup-root.csetup-theme-classic a.csetup-zoom-btn {
+	padding: 3px 6px !important;
+	font-size: 10px !important;
+	text-align: center;
+	white-space: nowrap;
 }
 
 .csetup-root.csetup-theme-modern .csetup-dir-bar,

--- a/html/browser/prefs_state.js
+++ b/html/browser/prefs_state.js
@@ -1,3 +1,9 @@
+// Targeted preview update — called from DM via output() to avoid full ShowChoices rebuild
+function update_char_preview(html) {
+	var el = document.getElementById('char_preview');
+	if (el) el.innerHTML = html;
+}
+
 // Автоскролл
 (function () {
 	'use strict';

--- a/modular_bluemoon/code/modules/client/modern_ru.dm
+++ b/modular_bluemoon/code/modules/client/modern_ru.dm
@@ -71,6 +71,7 @@
 	"preview_loadout"       = list("ru" = "Снаряжение",      "en" = "Loadout"),
 	"preview_naked"         = list("ru" = "Нагота",          "en" = "Naked"),
 	"preview_naked_aroused" = list("ru" = "Возбужденный",    "en" = "Aroused"),
+	"preview_reference"     = list("ru" = "Эталон",          "en" = "Reference"),
 
 	// Character creation tabs
 	"char_tab_general"     = list("ru" = "Основное",     "en" = "General"),
@@ -259,7 +260,7 @@
 	// Body size
 	"body_size"              = list("ru" = "Размер тела",						"en" = "Body Size"),
 	"normalized_size"        = list("ru" = "Нормализованный размер",			"en" = "Normalized Size"),
-	"scaled_appearance"      = list("ru" = "Масштабированное появление",		"en" = "Scaled Appearance"),
+	"scaled_appearance"      = list("ru" = "Режим масштабирования",				"en" = "Scaling Mode"),
 	"fuzzy"                  = list("ru" = "Размытый",							"en" = "Fuzzy"),
 	"sharp"                  = list("ru" = "Резкий",							"en" = "Sharp"),
 	"weight"                 = list("ru" = "Вес",								"en" = "Weight"),

--- a/modular_bluemoon/code/modules/client/modern_ru.dm
+++ b/modular_bluemoon/code/modules/client/modern_ru.dm
@@ -263,6 +263,7 @@
 	"scaled_appearance"      = list("ru" = "Режим масштабирования",				"en" = "Scaling Mode"),
 	"fuzzy"                  = list("ru" = "Размытый",							"en" = "Fuzzy"),
 	"sharp"                  = list("ru" = "Резкий",							"en" = "Sharp"),
+	"parts"                  = list("ru" = "По частям (тест)",				"en" = "Per-Part (WIP)"),
 	"weight"                 = list("ru" = "Вес",								"en" = "Weight"),
 
 	// Eyes

--- a/modular_splurt/code/modules/mob/living/living_defines.dm
+++ b/modular_splurt/code/modules/mob/living/living_defines.dm
@@ -3,3 +3,4 @@
 	var/admin_frozen = FALSE
 	var/admin_sleeping = FALSE
 	var/fuzzy = SCALED_SHARP
+	var/current_body_scale = 1

--- a/modular_splurt/code/modules/mob/living/living_defines.dm
+++ b/modular_splurt/code/modules/mob/living/living_defines.dm
@@ -2,4 +2,4 @@
 	// Admin CC
 	var/admin_frozen = FALSE
 	var/admin_sleeping = FALSE
-	var/fuzzy = FALSE
+	var/fuzzy = SCALED_SHARP

--- a/modular_splurt/code/modules/mob/living/living_update_icons.dm
+++ b/modular_splurt/code/modules/mob/living/living_update_icons.dm
@@ -1,5 +1,2 @@
 /mob/living/update_transform(do_animate)
-	appearance_flags |= PIXEL_SCALE
-	if(fuzzy)
-		appearance_flags &= ~PIXEL_SCALE
 	. = ..()

--- a/tgui/packages/tgui/interfaces/HairStylePicker.tsx
+++ b/tgui/packages/tgui/interfaces/HairStylePicker.tsx
@@ -2,10 +2,18 @@ import { useBackend, useLocalState } from '../backend';
 import { Box, Button, Input, Section, Stack } from '../components';
 import { PixelArtImage } from '../components';
 import { Window } from '../layouts';
+import { debounce } from 'common/timer';
 
 const PAGE_SIZE = 24;
 const ICON_SIZE = 64; // px – displayed size (32px native scaled 2x via CSS)
 const COLS = 6;       // icons per row
+
+// Module-level debounced navigate to avoid re-creating on every render.
+// Stores the latest act() reference and calls it after 300ms of inactivity.
+let _debouncedNavigateAct: ((action: string, payload: object) => void) | null = null;
+const debouncedNavigate = debounce((page: number, search: string) => {
+  _debouncedNavigateAct?.('navigate', { page, search });
+}, 300);
 
 interface HairStylePickerData {
   pick_type: 'hair' | 'facial_hair' | 'gradient';
@@ -45,6 +53,9 @@ export const HairStylePicker = (props, context) => {
     Math.ceil((filtered_names || []).length / PAGE_SIZE),
   );
 
+  // Keep module-level debounce in sync with current act() reference
+  _debouncedNavigateAct = act;
+
   const navigate = (page: number, search: string) => {
     const clampedPage = Math.max(0, Math.min(page, effectiveTotalPages - 1));
     setLocalPage(clampedPage);
@@ -54,7 +65,8 @@ export const HairStylePicker = (props, context) => {
   const onSearchChange = (_, value: string) => {
     setLocalSearch(value);
     setLocalPage(0);
-    navigate(0, value);
+    // Debounce server call — local state updates instantly for responsive UI
+    debouncedNavigate(0, value);
   };
 
   const onSelect = (style: string) => {


### PR DESCRIPTION
Переделал превью персонажа в настройках - раньше манекен пересоздавался с нуля на каждый чих, теперь он персистентный и обновляет только то, что реально изменилось (волосы поменял - перерисовались только волосы, а не весь моб целиком). Из-за этого всё стало заметно отзывчивее, тротл снизил с 500мс до 300мс

Превью теперь генерится через нормальный HTML с зумом и масштабированием, а не просто тупо иконку кидает. Добавил кэширование иконок для пикера причёсок - раньше на каждую причёску гонялся getFlatIcon, теперь базовая иконка собирается один раз через Blend и переиспользуется

Начал пилить режим масштабирования по частям (per-part scaling) - пока WIP, но основа уже есть: дефайны, сохранение в сейвфайл, оверлеи отдельных частей тела умеют скейлиться независимо. Плюс всякие гарды на лоадаут и санитизация сейвов чтобы ничего не сломалось при переходе на новый формат

Ну и по мелочи - HairStylePicker причесали в TGUI, переводы обновил